### PR TITLE
Allow docstrings to happen anywhere in the code

### DIFF
--- a/ftplugin/python/SimpylFold.vim
+++ b/ftplugin/python/SimpylFold.vim
@@ -5,7 +5,7 @@ let b:loaded_SimpylFold = 1
 
 let s:blank_regex = '^\s*$'
 let s:def_regex = '^\s*\%(class\|def\) \w\+'
-let s:multiline_def_end_regex = '):$'
+let s:continuation_regex = '\\$'
 let s:docstring_start_regex = '^\s*\("""\|''''''\)\%(.*\1\s*$\)\@!'
 let s:docstring_end_single_regex = '''''''\s*$'
 let s:docstring_end_double_regex = '"""\s*$'
@@ -90,12 +90,7 @@ function! SimpylFold(lnum)
     endif
 
     let docstring_match = matchlist(line, s:docstring_start_regex)
-    let prev_line = getline(a:lnum - 1)
-    if !b:in_docstring &&
-        \ (
-          \ prev_line =~ s:def_regex ||
-          \ prev_line =~ s:multiline_def_end_regex
-        \ ) &&
+    if !b:in_docstring && getline(a:lnum - 1) !~ s:continuation_regex &&
         \ len(docstring_match)
         let this_fl = s:NumContainingDefs(a:lnum) + 1
         let b:in_docstring = 1


### PR DESCRIPTION
In Python docstring can happen just in the middle of the code, e.g. documentation for class or instance variables. So let's fold them.
This also removes assumption that any string ending with '):' is an end for def: or class: (it can by if: or anything else).
