### PR TITLE
Folding for raw docstrings

### DIFF
--- a/ftplugin/python/SimpylFold.vim
+++ b/ftplugin/python/SimpylFold.vim
@@ -6,7 +6,7 @@ let b:loaded_SimpylFold = 1
 let s:blank_regex = '\v^\s*(\#.*)?$'
 let s:def_regex = '^\%(\s*\%(class\|def\) \w\+\|if\s*__name__\s*==\s*''__main__'':\s*\)'
 let s:multiline_def_end_regex = '):$'
-let s:docstring_start_regex = '^\s*\("""\|''''''\)\%(.*\1\s*$\)\@!'
+let s:docstring_start_regex = '^\s*\("""\|r"""\|''''''\)\%(.*\1\s*$\)\@!'
 let s:docstring_end_single_regex = '''''''\s*$'
 let s:docstring_end_double_regex = '"""\s*$'
 
@@ -119,10 +119,10 @@ function! SimpylFold(lnum)
         \ len(docstring_match)
         let this_fl = s:NumContainingDefs(a:lnum) + fold_docstrings
         let b:in_docstring = 1
-        if docstring_match[1] == '"""'
-            let b:docstring_end_regex = s:docstring_end_double_regex
-        else
+        if docstring_match[1] == "''''''"
             let b:docstring_end_regex = s:docstring_end_single_regex
+        else
+            let b:docstring_end_regex = s:docstring_end_double_regex
         endif
     elseif b:in_docstring
         let this_fl = s:NumContainingDefs(a:lnum) + fold_docstrings

--- a/ftplugin/python/SimpylFold.vim
+++ b/ftplugin/python/SimpylFold.vim
@@ -6,7 +6,7 @@ let b:loaded_SimpylFold = 1
 let s:blank_regex = '\v^\s*(\#.*)?$'
 let s:def_regex = '^\%(\s*\%(class\|def\) \w\+\|if\s*__name__\s*==\s*''__main__'':\s*\)'
 let s:multiline_def_end_regex = '):$'
-let s:docstring_start_regex = '^\s*\("""\|r"""\|''''''\)\%(.*\1\s*$\)\@!'
+let s:docstring_start_regex = '^\s*[rR]\?\("""\|''''''\)\%(.*\1\s*$\)\@!'
 let s:docstring_end_single_regex = '''''''\s*$'
 let s:docstring_end_double_regex = '"""\s*$'
 
@@ -119,10 +119,10 @@ function! SimpylFold(lnum)
         \ len(docstring_match)
         let this_fl = s:NumContainingDefs(a:lnum) + fold_docstrings
         let b:in_docstring = 1
-        if docstring_match[1] == "''''''"
-            let b:docstring_end_regex = s:docstring_end_single_regex
-        else
+        if docstring_match[1] =~ '[rR]\?"""'
             let b:docstring_end_regex = s:docstring_end_double_regex
+        else
+            let b:docstring_end_regex = s:docstring_end_single_regex
         endif
     elseif b:in_docstring
         let this_fl = s:NumContainingDefs(a:lnum) + fold_docstrings

--- a/ftplugin/python/SimpylFold.vim
+++ b/ftplugin/python/SimpylFold.vim
@@ -119,7 +119,7 @@ function! SimpylFold(lnum)
         \ len(docstring_match)
         let this_fl = s:NumContainingDefs(a:lnum) + fold_docstrings
         let b:in_docstring = 1
-        if docstring_match[1] =~ '[rR]\?"""'
+        if docstring_match[1] == '"""'
             let b:docstring_end_regex = s:docstring_end_double_regex
         else
             let b:docstring_end_regex = s:docstring_end_single_regex


### PR DESCRIPTION
When a docstring contains latex expressions, ex. for Sphinx documentation,  it is convenient to have the docstring as a raw string, e.g. 

    r""" This is a docstring that contains a latex expression
        y = \sum_{i=0}^{|\mathcal{D}|} (W_i \cdot X_i) +  b
    """

With this patch, SimpylFold will now take care and fold this kind of docstrings.