### PR TITLE
Fold Python's imports with VIM / SimpylFold

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ And if you don't want to see your docstrings folded, add this:
 
     let g:SimpylFold_fold_docstring = 0
 
+And if you don't want to see your imports folded, add this:
+
+    let g:SimpylFold_fold_import = 0
+
 In order for SimpylFold to be properly loaded in certain cases, you'll have to add lines like the following to your `.vimrc` (see issue #27):
 
 ```vim


### PR DESCRIPTION
**A new feature to fold/group the Python imports (like the IDE Pycharm):**
```
    from module import name
    import module
```

Folding the imports is useful because Python programmers spend more time
in the classes/methods rather than imports. It is always interesting to
fold the imports and unfold them only when we need to import a new
module in our Python source code.

**For those who don't want to fold their Python imports, they can use this
option:**
```
    let g:SimpylFold_fold_import = 0
```