### PR TITLE
Adding support for 'async' keyword.

### DIFF
--- a/ftplugin/python/SimpylFold.vim
+++ b/ftplugin/python/SimpylFold.vim
@@ -5,7 +5,7 @@ let b:loaded_SimpylFold = 1
 
 let s:blank_regex = '\v^\s*(\#.*)?$'
 if &ft == 'pyrex' || &ft == 'cython'
-    let b:def_regex = '\v^\s*%(%(class|def|%(async\s+)?def|cdef|cpdef|ctypedef)\s+\w+)|cdef\s*:\s*'
+    let b:def_regex = '\v^\s*%(%(class|%(async\s+)?def|cdef|cpdef|ctypedef)\s+\w+)|cdef\s*:\s*'
 else
     let b:def_regex = '\v^\s*%(class|%(async\s+)?def)\s+\w+|if\s*__name__\s*\=\=\s*%("__main__"|''__main__'')\s*:\s*'
 endif

--- a/ftplugin/python/SimpylFold.vim
+++ b/ftplugin/python/SimpylFold.vim
@@ -5,9 +5,9 @@ let b:loaded_SimpylFold = 1
 
 let s:blank_regex = '\v^\s*(\#.*)?$'
 if &ft == 'pyrex' || &ft == 'cython'
-    let b:def_regex = '\v^\s*%(%(class|def|async +def|cdef|cpdef|ctypedef) \w+)|cdef:'
+    let b:def_regex = '\v^\s*%(%(class|def|%(async\s+)?def|cdef|cpdef|ctypedef)\s+\w+)|cdef\s*:\s*'
 else
-    let b:def_regex = '^\%(\s*\%(class\|async\s\+def\|def\) \w\+\|if\s*__name__\s*==\s*''__main__'':\s*\)'
+    let b:def_regex = '\v^\s*%(class|%(async\s+)?def)\s+\w+|if\s*__name__\s*\=\=\s*%("__main__"|''__main__'')\s*:\s*'
 endif
 let s:multiline_def_end_regex = '):$'
 let s:docstring_start_regex = '^\s*[rR]\?\("""\|''''''\)\%(.*\1\s*$\)\@!'

--- a/ftplugin/python/SimpylFold.vim
+++ b/ftplugin/python/SimpylFold.vim
@@ -5,9 +5,9 @@ let b:loaded_SimpylFold = 1
 
 let s:blank_regex = '\v^\s*(\#.*)?$'
 if &ft == 'pyrex' || &ft == 'cython'
-    let b:def_regex = '\v^\s*%(%(class|def|cdef|cpdef|ctypedef) \w+)|cdef:'
+    let b:def_regex = '\v^\s*%(%(class|def|async +def|cdef|cpdef|ctypedef) \w+)|cdef:'
 else
-    let b:def_regex = '^\%(\s*\%(class\|def\) \w\+\|if\s*__name__\s*==\s*''__main__'':\s*\)'
+    let b:def_regex = '^\%(\s*\%(class\|async\s\+def\|def\) \w\+\|if\s*__name__\s*==\s*''__main__'':\s*\)'
 endif
 let s:multiline_def_end_regex = '):$'
 let s:docstring_start_regex = '^\s*[rR]\?\("""\|''''''\)\%(.*\1\s*$\)\@!'


### PR DESCRIPTION
With python 3.5 `async` keyword has been added,
in order to clarify asynchronous programming in Python,
with that syntax the function will be a couroutine function
(aka a function that defines a coroutine),
an alternative to obtain the same behavior is to decorate
the function with `@asyncio.coroutine`.

In older python release the keywords `yield` and `yield from` have been used,
a more detail overview should be necessary here, but maybe is out of scope.

For further information see: [python 3.5 what's new](https://docs.python.org/3/whatsnew/3.5.html#new-features), [PEP492](https://www.python.org/dev/peps/pep-0492/)

With this addition in the parsing regex:
`async\s\+def\|`

The plugin will be able to fold code using the newly added syntax, as mentioned in #57, like:
```
async def coro():
    return 'spam'
```
but also (note several spaces between keywords):
```
async  def coro():
    return 'spam'
```
I'm not taking into account PEP8 style compliance
because I believe that is beyond of the scope of this plugin,
but I'm not sure if it's the right choice.
