### PR TITLE
Match multi-line strings beginning on a line containing other strings

### DIFF
--- a/autoload/SimpylFold.vim
+++ b/autoload/SimpylFold.vim
@@ -4,7 +4,7 @@ let s:multi_def_end_regex = '):\s*$'
 let s:multi_def_end_solo_regex = '^\s*):\s*$'
 let s:string_prefix_regex = '^\s*[bBfFrRuU]\{0,2}\("""\|''''''\|"\|''\)'
 let s:multi_string_start_regex =
-    \ '^\([^''"]*\%(\([''"]\)\%([^''"]\|\\[''"]\)*\2\)*[^''"]*\)[bBfFrRuU]\{0,2}\("""\|''''''\)\%(.*\3\s*$\)\@!'
+    \ '^\(\%([^''"]*\%(\([''"]\)\%([^''"]\|\\[''"]\)*\2\)\)*[^''"]*\)[bBfFrRuU]\{0,2}\("""\|''''''\)\%(.*\3\s*$\)\@!'
 let s:import_start_regex = '^\s*\%(from\|import\)'
 let s:import_cont_regex = '\%(from.*\((\)[^)]*\|.*\(\\\)\)$'
 let s:import_end_paren_regex = ')\s*$'

--- a/autoload/SimpylFold.vim
+++ b/autoload/SimpylFold.vim
@@ -3,6 +3,14 @@ let s:comment_regex = '^\s*#'
 let s:multi_def_end_regex = '):\s*$'
 let s:multi_def_end_solo_regex = '^\s*):\s*$'
 let s:string_prefix_regex = '^\s*[bBfFrRuU]\{0,2}\("""\|''''''\|"\|''\)'
+" Match zero or more of the following:
+"   - A sequence of zero or more non-quote characters
+"   - A string, consisting of 2 matching quote characters, separated by zero
+"     or more of:
+"       - Non-quote characters
+"       - Escaped quote characters
+" Followed by another sequence of zero or more non-quote characters,
+" Followed by the start of a multi-line string
 let s:multi_string_start_regex =
     \ '^\(\%([^''"]*\%(\([''"]\)\%([^''"]\|\\[''"]\)*\2\)\)*[^''"]*\)[bBfFrRuU]\{0,2}\("""\|''''''\)\%(.*\3\s*$\)\@!'
 let s:import_start_regex = '^\s*\%(from\|import\)'

--- a/autoload/SimpylFold.vim
+++ b/autoload/SimpylFold.vim
@@ -3,7 +3,8 @@ let s:comment_regex = '^\s*#'
 let s:multi_def_end_regex = '):\s*$'
 let s:multi_def_end_solo_regex = '^\s*):\s*$'
 let s:string_prefix_regex = '^\s*[bBfFrRuU]\{0,2}\("""\|''''''\|"\|''\)'
-let s:multi_string_start_regex = '^\([^''"]\{-}\)[bBfFrRuU]\{0,2}\("""\|''''''\)\%(.*\2\s*$\)\@!'
+let s:multi_string_start_regex =
+    \ '^\([^''"]*\%(\([''"]\)\%([^''"]\|\\[''"]\)*\2\)*[^''"]*\)[bBfFrRuU]\{0,2}\("""\|''''''\)\%(.*\3\s*$\)\@!'
 let s:import_start_regex = '^\s*\%(from\|import\)'
 let s:import_cont_regex = '\%(from.*\((\)[^)]*\|.*\(\\\)\)$'
 let s:import_end_paren_regex = ')\s*$'
@@ -173,7 +174,7 @@ function! s:cache() abort
         let string_match = matchlist(line, s:multi_string_start_regex)
         if !empty(string_match)
             let in_string = 1
-            let string_end_regex = string_match[2]
+            let string_end_regex = string_match[3]
 
             " Docstrings
             if b:SimpylFold_fold_docstring && string_match[1] =~# s:blank_regex


### PR DESCRIPTION
This fixes #82.

@nfnty How does this look to you? It makes the broken examples in #82 fold properly, but I'd appreciate another pair of eyes to reduce the likelihood that I'm introducing other bugs. The regex is quite complex, so it would be easy to miss something. Hopefully the comment makes it somewhat easier to follow.