### PR TITLE
Ability to not fold function names and docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,27 @@ following command to your `~/.config/nvim/init.vim` or `~/.vimrc`:
 ```vim
 let g:SimpylFold_docstring_preview = 1
 ```
-| Variable                         | Description                    | Default |
-| -------------------------------- | ------------------------------ | ------- |
-| `g:SimpylFold_docstring_preview` | Preview docstring in fold text | `0`     |
-| `g:SimpylFold_fold_docstring`    | Fold docstrings                | `1`     |
-| `b:SimpylFold_fold_docstring`    | Fold docstrings (buffer local) | `1`     |
-| `g:SimpylFold_fold_import`       | Fold imports                   | `1`     |
-| `b:SimpylFold_fold_import`       | Fold imports (buffer local)    | `1`     |
+| Variable                              | Description                    | Default |
+| ------------------------------------- | ------------------------------ | ------- |
+| `g:SimpylFold_docstring_preview`      | Preview docstring in fold text | `0`     |
+| `g:SimpylFold_fold_docstring`         | Fold docstrings                | `1`     |
+| `b:SimpylFold_fold_docstring`         | Fold docstrings (buffer local) | `1`     |
+| `g:SimpylFold_fold_import`            | Fold imports                   | `1`     |
+| `b:SimpylFold_fold_import`            | Fold imports (buffer local)    | `1`     |
+| `g:SimpylFold_unfold_function_names`  | Fold imports                   | `0`     |
+| `b:SimpylFold_unfold_function_names`  | Fold imports (buffer local)    | `0`     |
+| `g:SimpylFold_unfold_docstring`       | Fold imports                   | `0`     |
+| `b:SimpylFold_unfold_docstring`       | Fold imports (buffer local)    | `0`     |
+
+Using `SimpylFold_unfold_docstring` does have some caveats:
+
+To work properly, it needs `SimpylFold_fold_docstring` to be set to the
+default value `1` to find the docstring starting location. In addition, 
+`SimpylFold_fold_docstring` overrides the affect of 
+`SimpylFold_unfold_function_names` by having function names visible 
+constantly. This is intentional, but `g:SimpylFold_unfold_function_names`
+should still be set to 1 in the `.vimrc` file to properly handle double 
+lined function or class definitions. 
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ let g:SimpylFold_docstring_preview = 1
 | `b:SimpylFold_fold_docstring`         | Fold docstrings (buffer local) | `1`     |
 | `g:SimpylFold_fold_import`            | Fold imports                   | `1`     |
 | `b:SimpylFold_fold_import`            | Fold imports (buffer local)    | `1`     |
-| `g:SimpylFold_unfold_function_names`  | Fold imports                   | `0`     |
-| `b:SimpylFold_unfold_function_names`  | Fold imports (buffer local)    | `0`     |
-| `g:SimpylFold_unfold_docstring`       | Fold imports                   | `0`     |
-| `b:SimpylFold_unfold_docstring`       | Fold imports (buffer local)    | `0`     |
+| `g:SimpylFold_unfold_function_names`  | Fold imports                   | `1`     |
+| `b:SimpylFold_unfold_function_names`  | Fold imports (buffer local)    | `1`     |
+| `g:SimpylFold_unfold_docstring`       | Fold imports                   | `1`     |
+| `b:SimpylFold_unfold_docstring`       | Fold imports (buffer local)    | `1`     |
 
 Using `SimpylFold_unfold_docstring` does have some caveats:
 

--- a/autoload/SimpylFold.vim
+++ b/autoload/SimpylFold.vim
@@ -29,6 +29,14 @@ function! SimpylFold#BufferInit() abort
         let b:SimpylFold_fold_import =
             \ !exists('g:SimpylFold_fold_import') || g:SimpylFold_fold_import
     endif
+    if !exists('b:SimpylFold_unfold_function_name')
+        let b:SimpylFold_unfold_function_name=
+            \ !exists('g:SimpylFold_unfold_function_name') || g:SimpylFold_unfold_function_name
+    endif
+    if !exists('b:SimpylFold_unfold_docstring')
+        let b:SimpylFold_unfold_docstring=
+            \ !exists('g:SimpylFold_unfold_docstring') || g:SimpylFold_unfold_docstring
+    endif
 endfunction
 
 " Get spaces per indent setting
@@ -200,9 +208,15 @@ function! s:cache() abort
             else
                 if docstring_start != -1
                     let foldlevel += 1
-                    let cache[docstring_start]['foldexpr'] = '>' . foldlevel
+                    if b:SimpylFold_unfold_docstring
+                        let cache[docstring_start]['foldexpr'] = 0
+                        let docfold = 0
+                    else
+                        let cache[docstring_start]['foldexpr'] =  '>' . foldlevel
+                        let docfold = foldlevel
+                    endif
                     for lnum_docstring in range((docstring_start + 1), lnum)
-                        let cache[lnum_docstring]['foldexpr'] = foldlevel
+                        let cache[lnum_docstring]['foldexpr'] = docfold
                     endfor
                     let docstring_start = -1
                 endif
@@ -257,7 +271,10 @@ function! s:cache() abort
             let foldlevel = len(defs_stack) - 1
             let ind_def = ind
             call s:blanks_adj(cache, lnum, foldlevel)
-            let cache[lnum]['foldexpr'] = '>' . (foldlevel + 1)
+            let cache[lnum+b:SimpylFold_unfold_function_name]['foldexpr'] = '>' . (foldlevel + 1)
+            if b:SimpylFold_unfold_function_name
+                let cache[lnum]['foldexpr'] = (foldlevel + 1 - b:SimpylFold_unfold_function_name)
+            endif
             continue
         endif
 


### PR DESCRIPTION
I wanted the ability to see function names not be incorporated into the fold, similar to (Issue: folds the function names too? #108)  and also I saw that a lot of people wanted the ability to stop Docstrings from being folded (Issue: Option to start definition fold after docstring #84). So I added both of those. 

I just started using Vim about a week ago, so I wasn't able to find out how to change the default value of the variables to 0. I think that this should be done, otherwise when people run `PlugUpdate` or its equivalent, they will need to change their .vimrc. 

Thanks for Plugin btw, I absolutely love it, It's way better than the shitty folding that Atom had. 