### PR TITLE
autoload: Add option to fold away trailing blank lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ let g:SimpylFold_docstring_preview = 1
 | `b:SimpylFold_fold_docstring`    | Fold docstrings (buffer local) | `1`     |
 | `g:SimpylFold_fold_import`       | Fold imports                   | `1`     |
 | `b:SimpylFold_fold_import`       | Fold imports (buffer local)    | `1`     |
+| `g:SimpylFold_fold_blank`        | Fold trailing blank lines      | `0`     |
+| `b:SimpylFold_fold_blank`        | Fold trailing blanks (buffer)  | `0`     |
 
 ### Commands
 

--- a/autoload/SimpylFold.vim
+++ b/autoload/SimpylFold.vim
@@ -29,6 +29,10 @@ function! SimpylFold#BufferInit() abort
         let b:SimpylFold_fold_import =
             \ !exists('g:SimpylFold_fold_import') || g:SimpylFold_fold_import
     endif
+    if !exists('b:SimpylFold_fold_blank')
+        let b:SimpylFold_fold_blank =
+            \ exists('g:SimpylFold_fold_blank') && g:SimpylFold_fold_blank
+    endif
 endfunction
 
 " Get spaces per indent setting
@@ -68,6 +72,9 @@ endfunction
 
 " Adjust previous blanks and comments
 function! s:blanks_adj(cache, lnum, foldlevel) abort
+    if b:SimpylFold_fold_blank
+        return
+    endif
     let lnum_prev = a:lnum - 1
     while lnum_prev != 0 && (
             \ a:cache[lnum_prev]['is_blank'] || (


### PR DESCRIPTION
This feature has been requested previously.

PEP-8 suggests:

>Surround top-level function and class definitions with two blank lines.
>
>Method definitions inside a class are surrounded by a single blank line.

When not folding them away together with the functions / classes they separate, this leads to a lot of unused screen space, with a single line for a folded class definition and one or two blank lines following it. This PR adds a new configuration option `g:SimpylFold_fold_blank` to change this behavior. It defaults to false, which means the current folding behavior remains unless changed explicitly.